### PR TITLE
Added section compiling in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,34 @@ Goptical fork by Dmitry Galchinsky <galchinsky@gmail.com>. Very WIP.
 * different directory structure
 * cmake instead of autotools
 
+-----
+
+Compiling
+=====
+
+Tested for Linux Mint 18.3, but should also work for other Ubuntu-type Linux distributions:
+
+     $ sudo apt-get install libgsl-dev libgsl2 gsl-bin libgd3 libgd-tools libgd-dev libplplot-dev libplplot-c++11 freeglut3 freeglut3-dev libopencv-dev libdime-dev libxmu-dev libxmuu-dev
+
+First, clone the github repo by:
+
+     $ git clone https://github.com/galchinsky/goptical.git
+     $ cd goptical
+
+Then create a directory `build` and `cd` there:
+
+     $ mkdir build
+     $ cd build
+
+For creating the Makefiles via `cmake`, use:
+
+     $ cmake ../
+
+After successfully creating the Makefiles, perform `make`:
+
+     $ make
+
+As a result, you should find lots of examples in the `examples` sub directory which can be executed and the plots can be inspected by using, e.g., `inkscape`.
 
 -----
  Copyright (C) 2010-2011 Free Software Foundation, Inc


### PR DESCRIPTION
First of all great work! I've tried to compile the original goptical with autotools since forever and never got a useful result. With your fork, it was done in like 15 minutes. I just wanted to add the compile section into the README.md to get it more clear which dependencies are needed and what to do, to get goptical running.